### PR TITLE
Build any version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build images
+
+on:
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version:  # from https://deb.theforeman.org/pool/
+        - '1.21'
+        - '1.22'
+        - '1.23'
+        - '1.24'
+        - '2.0'
+        - '2.1'
+        - '2.2'
+        - '2.3'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build hammer ${{ matrix.version }}
+      run: docker build . --build-arg FOREMAN_VERSION=${{ matrix.version }} --tag quay.io/foreman/hammer:${{ matrix.version }}
+    - name: Publish hammer ${{ matrix.version }}
+      run: |
+        - docker login quay.io -u "${{ secrets.REGISTRY_USERNAME }}" -p "${{ secrets.REGISTRY_PASSWORD }}"
+        - docker push quay.io/foreman/hammer:${{ matrix.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,26 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget gnupg2 && \
-    echo "deb http://deb.theforeman.org/ bionic 1.22" > /etc/apt/sources.list.d/foreman.list && \
-    wget -q https://deb.theforeman.org/foreman.asc -O- | apt-key add - && \
-    apt-get update && apt-get install -y --no-install-recommends ruby-hammer-cli ruby-hammer-cli-foreman && \
-    apt-get remove curl gnupg2 wget -y && \ 
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ARG FOREMAN_VERSION=nightly
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y \
+    ca-certificates \
+    gnupg2 \
+    lsb-release \
+    wget \
+ && echo "deb http://deb.theforeman.org/ $(lsb_release -cs) ${FOREMAN_VERSION}" | tee /etc/apt/sources.list.d/foreman.list \
+ && wget -q https://deb.theforeman.org/foreman.asc -O- | apt-key add - \
+ && apt-get update \
+ && apt-get install --no-install-recommends -y \
+    ruby-hammer-cli-foreman \
+ && apt-get purge -y \
+    gnupg2 \
+    lsb-release \
+    wget \
+ && apt-get autoremove --purge -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /etc/hammer/
 


### PR DESCRIPTION
A few changes that generalize building the image.

- Any [hammer-cli-foreman version](https://deb.theforeman.org/pool/) can be used via `--build-arg FOREMAN_VERSION=x.y`
- Building the image is automatic with GitHub Actions (would push to the [Foreman project's Quay.io account](https://quay.io/organization/foreman))